### PR TITLE
Pass X-Is-Sandbox header in /subscribers/:id request if Rails app environment is available

### DIFF
--- a/lib/tarpon/request/subscriber.rb
+++ b/lib/tarpon/request/subscriber.rb
@@ -9,7 +9,8 @@ module Tarpon
       end
 
       def get_or_create # rubocop:disable Naming/AccessorMethodName
-        perform(method: :get, path: path, key: :public)
+        headers = { 'X-Is-Sandbox' => Rails.env.development? }
+        perform(method: :get, headers: headers, path: path, key: :public)
       end
 
       def delete

--- a/lib/tarpon/request/subscriber.rb
+++ b/lib/tarpon/request/subscriber.rb
@@ -9,7 +9,8 @@ module Tarpon
       end
 
       def get_or_create # rubocop:disable Naming/AccessorMethodName
-        headers = { 'X-Is-Sandbox' => Rails.env.development? }
+        headers = {}
+        headers['X-Is-Sandbox'] = Rails.env.development? if defined?(Rails)
         perform(method: :get, headers: headers, path: path, key: :public)
       end
 


### PR DESCRIPTION
- Sandbox purchases (i.e. iOS sandbox) are excluded from API V1 `GET /subscribers/:id` requests unless `X-Is-Sandbox: true` is passed in headers
- This PR updates the `get_or_create` method in `Tarpon::Request::Subscriber` to pass `X-Is-Sandbox` automatically if Rails is detected. The value is `true` if the Rails environment is `development`